### PR TITLE
Case changes on namespaces to adhere to OctoberCMS rules. 

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -25,8 +25,8 @@ class Plugin extends PluginBase
     public function boot()
     {
         // Create the donations table if it doesn't exist
-        if (!Schema::hasTable('Fuascailtdev_niapays_donations')) {
-            Schema::create('Fuascailtdev_niapays_donations', function (Blueprint $table) {
+        if (!Schema::hasTable('fuascailtdev_niapays_donations')) {
+            Schema::create('fuascailtdev_niapays_donations', function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
                 $table->string('email')->nullable();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Fuascailtdev/niapays-plugin",
+    "name": "fuascailtdev/niapays-plugin",
     "type": "october-plugin",
     "description": "A simple OctoberCMS plugin for accepting donations via Stripe.",
     "keywords": ["october", "octobercms", "plugin", "donation", "stripe"],

--- a/models/Donation.php
+++ b/models/Donation.php
@@ -6,7 +6,7 @@ class Donation extends Model
 {
     use \October\Rain\Database\Traits\Validation;
 
-    public $table = 'Fuascailtdev_niapays_donations';
+    public $table = 'fuascailtdev_niapays_donations';
 
     protected $fillable = [
         'name',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -7,7 +7,7 @@ class Settings extends Model
     public $implement = ['System.Behaviors.SettingsModel'];
 
     // A unique code for this settings model
-    public $settingsCode = 'Fuascailtdev_niapays_settings';
+    public $settingsCode = 'fuascailtdev_niapays_settings';
 
     // Reference to field configuration
     public $settingsFields = 'fields.yaml';

--- a/updates/0001_01_01_000001_create_donations_table.php
+++ b/updates/0001_01_01_000001_create_donations_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('Fuascailtdev_niapays_donations', function(Blueprint $table) {
+        Schema::create('fuascailtdev_niapays_donations', function(Blueprint $table) {
             $table->increments('id');
             $table->string('name')->nullable();
             $table->string('email')->nullable();
@@ -21,6 +21,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('Fuascailtdev_niapays_donations');
+        Schema::dropIfExists('fuascailtdev_niapays_donations');
     }
 };


### PR DESCRIPTION
## Summary by Sourcery

Ensure all plugin identifiers adhere to OctoberCMS lowercase naming conventions

Enhancements:
- Lowercase plugin package name in composer.json
- Convert database table references to lowercase in plugin boot, migrations, and model definitions
- Lowercase settingsCode identifier in Settings model